### PR TITLE
クラス名変更、変数名変更、その他微修正

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/RepositoryFragment.kt
@@ -10,9 +10,9 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.navArgs
 import coil.load
 import jp.co.yumemi.android.code_check.TopActivity.Companion.lastSearchDate
-import jp.co.yumemi.android.code_check.databinding.FragmentTwoBinding
+import jp.co.yumemi.android.code_check.databinding.FragmentRepositoryBinding
 
-class RepositoryFragment : Fragment(R.layout.fragment_two) {
+class RepositoryFragment : Fragment(R.layout.fragment_repository) {
 
     private val args: RepositoryFragmentArgs by navArgs()
 

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchFragment.kt
@@ -28,7 +28,7 @@ class SearchFragment: Fragment(R.layout.fragment_search) {
         val _dividerItemDecoration =
             DividerItemDecoration(context!!, _layoutManager.orientation)
         val _adapter = CustomAdapter(object : CustomAdapter.OnItemClickListener {
-            override fun itemClick(item: item) {
+            override fun itemClick(item: Items) {
                 gotoRepositoryFragment(item)
             }
         })
@@ -53,32 +53,31 @@ class SearchFragment: Fragment(R.layout.fragment_search) {
         }
     }
 
-    fun gotoRepositoryFragment(item: item) {
+    fun gotoRepositoryFragment(item: Items) {
         val _action = OneFragmentDirections
             .actionRepositoriesFragmentToRepositoryFragment(item = item)
         findNavController().navigate(_action)
     }
 }
 
-val diff_util= object: DiffUtil.ItemCallback<item>() {
-    override fun areItemsTheSame(oldItem: item, newItem: item): Boolean {
+val DIFF_UTIL = object: DiffUtil.ItemCallback<Items>() {
+    override fun areItemsTheSame(oldItem: Items, newItem: Items): Boolean {
         return oldItem.name == newItem.name
     }
 
-    override fun areContentsTheSame(oldItem: item, newItem: item): Boolean {
+    override fun areContentsTheSame(oldItem: Items, newItem: Items): Boolean {
         return oldItem == newItem
     }
-
 }
 // test
 class CustomAdapter(
     private val itemClickListener: OnItemClickListener,
-) : ListAdapter<item, CustomAdapter.ViewHolder>(diff_util) {
+) : ListAdapter<item, CustomAdapter.ViewHolder>(DIFF_UTIL) {
 
     class ViewHolder(view: View): RecyclerView.ViewHolder(view)
 
     interface OnItemClickListener {
-    	fun itemClick(item: item)
+    	fun itemClick(item: Items)
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/SearchViewModel.kt
@@ -76,7 +76,7 @@ class SearchViewModel(
 }
 
 @Parcelize
-data class item(
+data class Items(
     val name: String,
     val ownerIconUrl: String,
     val language: String,


### PR DESCRIPTION
クラス名はUpper Caseで始まるのが望ましいと判断し、
item を Itemsに変更（Itemだと通常のItemクラスと衝突があるため）
また、定数の変数名の命名規約に従い、Upper Caseと_で繋ぐ。
diff_util を DIFF_UTIL に変更